### PR TITLE
Add structured metadata for event

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -2,6 +2,29 @@
 {% block title %}{{ parent() }} &bull; {{ event_date }}{% endblock %}
 {% block meta_other %}
     <meta property="og:type" content="website" />
+
+    <script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Event",
+        "name": "South Dakota Code Camp",
+        "startDate" : "{{ event_date_iso }}",
+        "url" : "{{ url(app.request.attributes.get('_route')) }}",
+        "location" : {
+            "@type" : "Place",
+            "sameAs" : "http://www.southeasttech.edu/",
+            "name" : "Southeast Technical Institute",
+            "address" : {
+                "@type" : "PostalAddress",
+                "streetAddress": "2320 N. Career Ave",
+                "addressLocality": "Sioux Falls",
+                "addressRegion": "SD",
+                "addressCountry": "USA",
+                "postalCode": "57107"
+            }
+        }
+    }
+    </script>
 {% endblock %}
 {% block body %}
     <main role="main">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -32,6 +32,7 @@ twig:
     strict_variables: "%kernel.debug%"
     globals:
         event_date: "November 7, 2015"
+        event_date_iso: "2015-11-07"
 
 # Assetic Configuration
 assetic:


### PR DESCRIPTION
Attempt to get search engines to show the South Dakota Code Camp as an
event in search results by including Google-recommended JSON-LD event
metadata in the head.
